### PR TITLE
improve docker run command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ as normal.
 ## Running
 
 ```sh
-docker run --rm --volume=$(pwd):/srv/jekyll -p 127.0.0.1:4000:4000 \
+docker run --rm -it --volume=$(pwd):/srv/jekyll -p 127.0.0.1:4000:4000 \
   jekyll/jekyll jekyll s
 ```
 


### PR DESCRIPTION
The added options allow the display of jekyll output and stopping the server (and the container) with ctrl-c.