### PR TITLE
add -t flag to running example command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ is then we will try to install before trying to install gems again.
 ```sh
 # Labels requires Docker 1.7, if you get an error remove them.
 docker run --rm --label=jekyll --label=stable --volume=$(pwd):/srv/jekyll \
-  -p -t 127.0.0.1:4000:4000 jekyll/stable jekyll s
+  -t -p 127.0.0.1:4000:4000 jekyll/stable jekyll s
 ```
 
 ***If you do not provide a command then it will default to `jekyll s`.***

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ is then we will try to install before trying to install gems again.
 ```sh
 # Labels requires Docker 1.7, if you get an error remove them.
 docker run --rm --label=jekyll --label=stable --volume=$(pwd):/srv/jekyll \
-  -p 127.0.0.1:4000:4000 jekyll/stable jekyll s
+  -p -t 127.0.0.1:4000:4000 jekyll/stable jekyll s
 ```
 
 ***If you do not provide a command then it will default to `jekyll s`.***


### PR DESCRIPTION
Without the -t flag the following error is received:

    /usr/bin/startup: line 94: /dev/tty: No such device or address